### PR TITLE
Fixing incorrect handling of `imu.begin()`

### DIFF
--- a/ProtoStaxAG_Arduino_Giga_Display_Demo.ino
+++ b/ProtoStaxAG_Arduino_Giga_Display_Demo.ino
@@ -113,7 +113,7 @@ void setup() {
     while (1);
   }
 
-  if (imu.begin() == 1) {
+  if (!imu.begin()) {
     Serial.println("Failed to initialize imu!");
     while (1);
   }


### PR DESCRIPTION
According to [the documentation](https://github.com/arduino-libraries/Arduino_BMI270_BMM150/blob/master/docs/api.md#begin), the `.begin()` method returns "1 on success, 0 on failure."